### PR TITLE
Allow scanning multiple assemblies for Consumers

### DIFF
--- a/AsyncMonolith.MariaDb/StartupExtensions.cs
+++ b/AsyncMonolith.MariaDb/StartupExtensions.cs
@@ -17,14 +17,42 @@ public static class StartupExtensions
     /// </summary>
     /// <typeparam name="T">The DbContext type.</typeparam>
     /// <param name="services">The IServiceCollection to add the services to.</param>
+    /// <param name="settings">The action used to configure the settings.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddMariaDbAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> settings) where T : DbContext =>
+        AddMariaDbAsyncMonolith<T>(services, settings, AsyncMonolithSettings.Default);
+
+    /// <summary>
+    /// Adds MariaDb implementation of AsyncMonolith to the IServiceCollection.
+    /// </summary>
+    /// <typeparam name="T">The DbContext type.</typeparam>
+    /// <param name="services">The IServiceCollection to add the services to.</param>
     /// <param name="assembly">The assembly containing the DbContext.</param>
     /// <param name="settings">Optional AsyncMonolith settings.</param>
-    public static void AddMariaDbAsyncMonolith<T>(this IServiceCollection services, Assembly assembly,
-        AsyncMonolithSettings? settings = null) where T : DbContext
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    [Obsolete("This method is obsolete. Use the method that accepts an Action<AsyncMonolithSettings> instead.")]
+    public static IServiceCollection AddMariaDbAsyncMonolith<T>(
+        this IServiceCollection services,
+        Assembly assembly,
+        AsyncMonolithSettings? settings = null) where T : DbContext =>
+        AddMariaDbAsyncMonolith<T>(
+            services,
+            configuration => configuration.RegisterTypesFromAssembly(assembly),
+            settings ?? AsyncMonolithSettings.Default);
+
+    private static IServiceCollection AddMariaDbAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> configuration,
+        AsyncMonolithSettings settings) where T : DbContext
     {
-        services.InternalAddAsyncMonolith<T>(assembly, settings);
+        configuration(settings);
+
+        services.InternalAddAsyncMonolith<T>(settings);
         services.AddScoped<IProducerService, MariaDbProducerService<T>>();
         services.AddSingleton<IConsumerMessageFetcher, MariaDbConsumerMessageFetcher>();
         services.AddSingleton<IScheduledMessageFetcher, MariaDbScheduledMessageFetcher>();
+        return services;
     }
 }

--- a/AsyncMonolith.MsSql/StartupExtensions.cs
+++ b/AsyncMonolith.MsSql/StartupExtensions.cs
@@ -16,16 +16,41 @@ public static class StartupExtensions
     /// <summary>
     /// Adds the MsSqlAsyncMonolith services to the IServiceCollection.
     /// </summary>
+    /// <typeparam name="T">The DbContext type.</typeparam>
+    /// <param name="services">The IServiceCollection to add the services to.</param>
+    /// <param name="settings">The action used to configure the settings.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddMsSqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> settings) where T : DbContext =>
+        AddMsSqlAsyncMonolith<T>(services, settings, AsyncMonolithSettings.Default);
+    
+    /// <summary>
+    /// Adds the MsSqlAsyncMonolith services to the IServiceCollection.
+    /// </summary>
     /// <typeparam name="T">The type of the DbContext.</typeparam>
     /// <param name="services">The IServiceCollection to add the services to.</param>
     /// <param name="assembly">The assembly containing the DbContext and message handlers.</param>
     /// <param name="settings">The optional AsyncMonolithSettings.</param>
-    public static void AddMsSqlAsyncMonolith<T>(this IServiceCollection services, Assembly assembly,
-        AsyncMonolithSettings? settings = null) where T : DbContext
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    [Obsolete("This method is obsolete. Use the method that accepts an Action<AsyncMonolithSettings> instead.")]
+    public static IServiceCollection AddMsSqlAsyncMonolith<T>(this IServiceCollection services, Assembly assembly,
+        AsyncMonolithSettings? settings = null) where T : DbContext =>
+        AddMsSqlAsyncMonolith<T>(
+            services,
+            configuration => configuration.RegisterTypesFromAssembly(assembly),
+            settings ?? AsyncMonolithSettings.Default);
+
+    private static IServiceCollection AddMsSqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> configuration,
+        AsyncMonolithSettings settings) where T : DbContext
     {
-        services.InternalAddAsyncMonolith<T>(assembly, settings);
+        configuration(settings);
+        services.InternalAddAsyncMonolith<T>(settings);
         services.AddScoped<IProducerService, MsSqlProducerService<T>>();
         services.AddSingleton<IConsumerMessageFetcher, MsSqlConsumerMessageFetcher>();
         services.AddSingleton<IScheduledMessageFetcher, MsSqlScheduledMessageFetcher>();
+        return services;
     }
 }

--- a/AsyncMonolith.MySql/StartupExtensions.cs
+++ b/AsyncMonolith.MySql/StartupExtensions.cs
@@ -17,14 +17,39 @@ public static class StartupExtensions
     /// </summary>
     /// <typeparam name="T">The DbContext type.</typeparam>
     /// <param name="services">The IServiceCollection to add the services to.</param>
+    /// <param name="settings">The action used to configure the settings.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddMySqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> settings) where T : DbContext =>
+        AddMySqlAsyncMonolith<T>(services, settings, AsyncMonolithSettings.Default);
+
+    /// <summary>
+    /// Adds MySql implementation of AsyncMonolith to the IServiceCollection.
+    /// </summary>
+    /// <typeparam name="T">The DbContext type.</typeparam>
+    /// <param name="services">The IServiceCollection to add the services to.</param>
     /// <param name="assembly">The assembly containing the DbContext.</param>
     /// <param name="settings">Optional AsyncMonolith settings.</param>
-    public static void AddMySqlAsyncMonolith<T>(this IServiceCollection services, Assembly assembly,
-        AsyncMonolithSettings? settings = null) where T : DbContext
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    [Obsolete("This method is obsolete. Use the method that accepts an Action<AsyncMonolithSettings> instead.")]
+    public static IServiceCollection AddMySqlAsyncMonolith<T>(this IServiceCollection services, Assembly assembly,
+        AsyncMonolithSettings? settings = null) where T : DbContext =>
+        AddMySqlAsyncMonolith<T>(
+            services,
+            configuration => configuration.RegisterTypesFromAssembly(assembly),
+            settings ?? AsyncMonolithSettings.Default);
+
+    private static IServiceCollection AddMySqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> configuration,
+        AsyncMonolithSettings settings) where T : DbContext
     {
-        services.InternalAddAsyncMonolith<T>(assembly, settings);
+        configuration(settings);
+        services.InternalAddAsyncMonolith<T>(settings);
         services.AddScoped<IProducerService, MySqlProducerService<T>>();
         services.AddSingleton<IConsumerMessageFetcher, MySqlConsumerMessageFetcher>();
         services.AddSingleton<IScheduledMessageFetcher, MySqlScheduledMessageFetcher>();
+        return services;
     }
 }

--- a/AsyncMonolith.PostgreSql/StartupExtensions.cs
+++ b/AsyncMonolith.PostgreSql/StartupExtensions.cs
@@ -18,14 +18,41 @@ public static class StartupExtensions
     /// </summary>
     /// <typeparam name="T">The type of the DbContext.</typeparam>
     /// <param name="services">The service collection.</param>
+    /// <param name="settings">The action used to configure the settings.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddPostgreSqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> settings) where T : DbContext =>
+        AddPostgreSqlAsyncMonolith<T>(services, settings, AsyncMonolithSettings.Default);
+
+    /// <summary>
+    /// Adds the PostgreSql implementation of the AsyncMonolith to the service collection.
+    /// </summary>
+    /// <typeparam name="T">The type of the DbContext.</typeparam>
+    /// <param name="services">The service collection.</param>
     /// <param name="assembly">The assembly containing the DbContext.</param>
     /// <param name="settings">The optional AsyncMonolith settings.</param>
-    public static void AddPostgreSqlAsyncMonolith<T>(this IServiceCollection services, Assembly assembly,
-        AsyncMonolithSettings? settings = null) where T : DbContext
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    [Obsolete("This method is obsolete. Use the method that accepts an Action<AsyncMonolithSettings> instead.")]
+    public static IServiceCollection AddPostgreSqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Assembly assembly,
+        AsyncMonolithSettings? settings = null) where T : DbContext =>
+        AddPostgreSqlAsyncMonolith<T>(
+            services,
+            configuration => configuration.RegisterTypesFromAssembly(assembly),
+            settings ?? AsyncMonolithSettings.Default);
+
+    private static IServiceCollection AddPostgreSqlAsyncMonolith<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> configuration,
+        AsyncMonolithSettings settings) where T : DbContext
     {
-        services.InternalAddAsyncMonolith<T>(assembly, settings);
+        configuration(settings);
+        services.InternalAddAsyncMonolith<T>(settings);
         services.AddScoped<IProducerService, PostgreSqlProducerService<T>>();
         services.AddSingleton<IConsumerMessageFetcher, PostgreSqlConsumerMessageFetcher>();
         services.AddSingleton<IScheduledMessageFetcher, PostgreSqlScheduledMessageFetcher>();
+        return services;
     }
 }

--- a/AsyncMonolith.TestHelpers/SetupTestHelpers.cs
+++ b/AsyncMonolith.TestHelpers/SetupTestHelpers.cs
@@ -16,19 +16,38 @@ public static class SetupTestHelpers
     /// Adds fake implementations of AsyncMonolith base services for testing purposes.
     /// </summary>
     /// <param name="services">The service collection.</param>
+    /// <param name="settings">The action used to configure the settings.</param>
+    public static IServiceCollection AddFakeAsyncMonolithBaseServices(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> settings) =>
+        AddFakeAsyncMonolithBaseServices(services, settings, AsyncMonolithSettings.Default);
+
+    /// <summary>
+    /// Adds fake implementations of AsyncMonolith base services for testing purposes.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
     /// <param name="assembly">The assembly containing the consumers.</param>
     /// <param name="settings">Optional AsyncMonolith settings.</param>
-    public static void AddFakeAsyncMonolithBaseServices(
+    [Obsolete("This method is obsolete. Use the method that accepts an Action<AsyncMonolithSettings> instead.")]
+    public static IServiceCollection AddFakeAsyncMonolithBaseServices(
         this IServiceCollection services,
         Assembly assembly,
-        AsyncMonolithSettings? settings = null)
-    {
-        settings = services.InternalConfigureAsyncMonolithSettings(settings);
-        services.InternalRegisterAsyncMonolithConsumers(assembly, settings);
-        services.AddSingleton<IAsyncMonolithIdGenerator>(new FakeIdGenerator());
-        services.AddScoped<IScheduleService, FakeScheduleService>();
-        services.AddScoped<IProducerService, FakeProducerService>();
-    }
+        AsyncMonolithSettings? settings = null) =>
+        AddFakeAsyncMonolithBaseServices(
+            services,
+            configuration => configuration.RegisterTypesFromAssembly(assembly),
+            settings ?? AsyncMonolithSettings.Default);
+
+    /// <summary>
+    /// Adds real implementations of AsyncMonolith base services for production use.
+    /// </summary>
+    /// <typeparam name="T">The DbContext type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="settings">The action used to configure the settings.</param>
+    public static IServiceCollection AddRealAsyncMonolithBaseServices<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> settings) where T : DbContext =>
+        AddRealAsyncMonolithBaseServices<T>(services, settings, AsyncMonolithSettings.Default);
 
     /// <summary>
     /// Adds real implementations of AsyncMonolith base services for production use.
@@ -37,14 +56,40 @@ public static class SetupTestHelpers
     /// <param name="services">The service collection.</param>
     /// <param name="assembly">The assembly containing the consumers.</param>
     /// <param name="settings">Optional AsyncMonolith settings.</param>
-    public static void AddRealAsyncMonolithBaseServices<T>(
+    [Obsolete("This method is obsolete. Use the method that accepts an Action<AsyncMonolithSettings> instead.")]
+    public static IServiceCollection AddRealAsyncMonolithBaseServices<T>(
         this IServiceCollection services,
         Assembly assembly,
-        AsyncMonolithSettings? settings = null) where T : DbContext
+        AsyncMonolithSettings? settings = null) where T : DbContext =>
+        AddRealAsyncMonolithBaseServices<T>(
+            services,
+            configuration => configuration.RegisterTypesFromAssembly(assembly),
+            settings ?? AsyncMonolithSettings.Default);
+
+    private static IServiceCollection AddFakeAsyncMonolithBaseServices(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> configuration,
+        AsyncMonolithSettings settings)
     {
-        settings = services.InternalConfigureAsyncMonolithSettings(settings);
-        services.InternalRegisterAsyncMonolithConsumers(assembly, settings);
+        configuration(settings);
+        services.InternalConfigureAsyncMonolithSettings(settings);
+        services.InternalRegisterAsyncMonolithConsumers(settings);
+        services.AddSingleton<IAsyncMonolithIdGenerator>(new FakeIdGenerator());
+        services.AddScoped<IScheduleService, FakeScheduleService>();
+        services.AddScoped<IProducerService, FakeProducerService>();
+        return services;
+    }
+
+    private static IServiceCollection AddRealAsyncMonolithBaseServices<T>(
+        this IServiceCollection services,
+        Action<AsyncMonolithSettings> configuration,
+        AsyncMonolithSettings settings) where T : DbContext
+    {
+        configuration(settings);
+        services.InternalConfigureAsyncMonolithSettings(settings);
+        services.InternalRegisterAsyncMonolithConsumers(settings);
         services.AddSingleton<IAsyncMonolithIdGenerator>(new AsyncMonolithIdGenerator());
         services.AddScoped<IScheduleService, ScheduleService<T>>();
+        return services;
     }
 }

--- a/AsyncMonolith.Tests/Infra/TestServiceHelpers.cs
+++ b/AsyncMonolith.Tests/Infra/TestServiceHelpers.cs
@@ -20,7 +20,7 @@ public static class TestServiceHelpers
     public static void AddInMemoryDb(this ServiceCollection services)
     {
         var dbId = Guid.NewGuid().ToString();
-        services.AddDbContext<TestDbContext>((sp, options) => { options.UseInMemoryDatabase(dbId); }
+        services.AddDbContext<TestDbContext>((_, options) => { options.UseInMemoryDatabase(dbId); }
         );
     }
 
@@ -31,8 +31,9 @@ public static class TestServiceHelpers
         services.AddSingleton<TimeProvider>(fakeTime);
         services.AddLogging();
 
-        settings = services.InternalConfigureAsyncMonolithSettings(settings);
-        services.InternalRegisterAsyncMonolithConsumers(Assembly.GetExecutingAssembly(), settings);
+        services.InternalConfigureAsyncMonolithSettings(settings);
+        settings.RegisterTypesFromAssembly(Assembly.GetExecutingAssembly());
+        services.InternalRegisterAsyncMonolithConsumers(settings);
         services.AddSingleton<IAsyncMonolithIdGenerator>(new FakeIdGenerator());
         services.AddScoped<IScheduleService, ScheduleService<TestDbContext>>();
         switch (dbType)

--- a/AsyncMonolith/AsyncMonolith.csproj
+++ b/AsyncMonolith/AsyncMonolith.csproj
@@ -28,9 +28,13 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>AsyncMonolith.Tests</_Parameter1>
-		</AssemblyAttribute>
+		<InternalsVisibleTo Include="$(AssemblyName).Ef" />
+		<InternalsVisibleTo Include="$(AssemblyName).MariaDb" />
+		<InternalsVisibleTo Include="$(AssemblyName).MsSql" />
+		<InternalsVisibleTo Include="$(AssemblyName).MySql" />
+		<InternalsVisibleTo Include="$(AssemblyName).PostgreSql" />
+		<InternalsVisibleTo Include="$(AssemblyName).TestHelpers" />
+		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="logo.png">

--- a/AsyncMonolith/Utilities/AsyncMonolithSettings.cs
+++ b/AsyncMonolith/Utilities/AsyncMonolithSettings.cs
@@ -1,10 +1,14 @@
-﻿namespace AsyncMonolith.Utilities;
+﻿using System.Reflection;
+
+namespace AsyncMonolith.Utilities;
 
 /// <summary>
 ///     Represents the settings for the AsyncMonolith application.
 /// </summary>
 public class AsyncMonolithSettings
 {
+    internal readonly HashSet<Assembly> AssembliesToRegister = [];
+
     /// <summary>
     ///     Gets or sets the maximum number of attempts for processing a message.
     ///     Default: 5, Min: 1, Max N/A
@@ -66,4 +70,43 @@ public class AsyncMonolithSettings
         ScheduledMessageProcessorCount = 1,
         ProcessorBatchSize = 5
     };
+    
+    /// <summary>
+    /// Register consumers and payloads from assembly containing given type.
+    /// </summary>
+    /// <typeparam name="T">Type from assembly to scan.</typeparam>
+    /// <returns>The current instance to continue configuration.</returns>
+    public AsyncMonolithSettings RegisterTypesFromAssemblyContaining<T>()
+        => RegisterTypesFromAssemblyContaining(typeof(T));
+
+    /// <summary>
+    /// Register consumers and payloads from assembly containing given type.
+    /// </summary>
+    /// <param name="type">Type from assembly to scan.</param>
+    /// <returns>The current instance to continue configuration.</returns>
+    public AsyncMonolithSettings RegisterTypesFromAssemblyContaining(Type type)
+        => RegisterTypesFromAssembly(type.Assembly);
+
+    /// <summary>
+    /// Register consumers and payloads from assembly.
+    /// </summary>
+    /// <param name="assembly">Assembly to scan</param>
+    /// <returns>The current instance to continue configuration.</returns>
+    public AsyncMonolithSettings RegisterTypesFromAssembly(Assembly assembly)
+        => RegisterTypesFromAssemblies([assembly]);
+
+    /// <summary>
+    /// Register consumers and payloads from assemblies.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to scan.</param>
+    /// <returns>The current instance to continue configuration.</returns>
+    public AsyncMonolithSettings RegisterTypesFromAssemblies(params Assembly[] assemblies)
+    {
+        foreach (var assembly in assemblies)
+        {
+            AssembliesToRegister.Add(assembly);
+        }
+
+        return this;
+    }
 }

--- a/Demo/Counter/ValueSubmittedConsumer.cs
+++ b/Demo/Counter/ValueSubmittedConsumer.cs
@@ -15,7 +15,7 @@ public class ValueSubmittedConsumer : BaseConsumer<ValueSubmitted>
         _producerService = producerService;
     }
 
-    public override async Task Consume(ValueSubmitted message, CancellationToken cancellationToken)
+    public override async Task Consume(ValueSubmitted message, CancellationToken cancellationToken = default)
     {
         var newValue = new SubmittedValue
         {
@@ -23,7 +23,7 @@ public class ValueSubmittedConsumer : BaseConsumer<ValueSubmitted>
         };
 
         _dbContext.SubmittedValues.Add(newValue);
-        _producerService.Produce(new ValuePersisted());
+        await _producerService.Produce(new ValuePersisted(), cancellationToken: cancellationToken);
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -38,17 +38,17 @@ public class Program
 
 
         builder.Services.AddSingleton(TimeProvider.System);
-        builder.Services.AddPostgreSqlAsyncMonolith<ApplicationDbContext>(Assembly.GetExecutingAssembly(),
-            new AsyncMonolithSettings
-            {
-                AttemptDelay = 10,
-                MaxAttempts = 5,
-                ProcessorMinDelay = 10,
-                ProcessorMaxDelay = 100,
-                ConsumerMessageProcessorCount = 1,
-                ScheduledMessageProcessorCount = 1,
-                ProcessorBatchSize = 10
-            });
+        builder.Services.AddPostgreSqlAsyncMonolith<ApplicationDbContext>(settings =>
+        {
+            settings.RegisterTypesFromAssembly(Assembly.GetExecutingAssembly());
+            settings.AttemptDelay = 10;
+            settings.MaxAttempts = 5;
+            settings.ProcessorMinDelay = 10;
+            settings.ProcessorMaxDelay = 100;
+            settings.ConsumerMessageProcessorCount = 1;
+            settings.ScheduledMessageProcessorCount = 1;
+            settings.ProcessorBatchSize = 10;
+        });
 
         builder.Services.AddControllers();
         builder.Services.AddScoped<TotalValueService>();

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,7 +43,7 @@ Setup your DbContext
 
 ***If you're not using ef migrations check out the sql to configure your database [here](https://github.com/Timmoth/AsyncMonolith/tree/main/Schemas)***
 
-Register your dependencies
+Register your dependencies and configure settings
 
 ```csharp
 
@@ -57,19 +57,25 @@ Register your dependencies
 	// services.AddMySqlAsyncMonolith
 	// services.AddPostgreSqlAsyncMonolith
 	// services.AddMariaDbAsyncMonolith
-
-    builder.Services.AddPostgreSqlAsyncMonolith<ApplicationDbContext>(Assembly.GetExecutingAssembly(), new AsyncMonolithSettings()
+    builder.Services.AddPostgreSqlAsyncMonolith<ApplicationDbContext>(settings =>
     {
-        AttemptDelay = 10, // Seconds before a failed message is retried
-        MaxAttempts = 5, // Number of times a failed message is retried
-        ProcessorMinDelay = 10, // Minimum millisecond delay before the next batch is processed
-        ProcessorMaxDelay = 1000, // Maximum millisecond delay before the next batch is processed
-		ProcessorBatchSize = 5, // The number of messages to process in a single batch
-        ConsumerMessageProcessorCount = 2, // The number of concurrent consumer message processors to run in each app instance
-        ScheduledMessageProcessorCount = 1, // The number of concurrent scheduled message processors to run in each app instance
-        DefaultConsumerTimeout = 10 // The default number of seconds before a consumer will timeout
+        settings.RegisterTypesFromAssembly(Assembly.GetExecutingAssembly());
+        settings.AttemptDelay = 10, // Seconds before a failed message is retried
+        settings.MaxAttempts = 5, // Number of times a failed message is retried
+        settings.ProcessorMinDelay = 10, // Minimum millisecond delay before the next batch is processed
+        settings.ProcessorMaxDelay = 1000, // Maximum millisecond delay before the next batch is processed
+		settings.ProcessorBatchSize = 5, // The number of messages to process in a single batch
+        settings.ConsumerMessageProcessorCount = 2, // The number of concurrent consumer message processors to run in each app instance
+        settings.ScheduledMessageProcessorCount = 1, // The number of concurrent scheduled message processors to run in each app instance
+        settings.DefaultConsumerTimeout = 10 // The default number of seconds before a consumer will timeout
     });
 ```
+The following methods are available on the `AsyncMonolithSettings` passed into the `settings` lambda:
+
+- `RegisterTypesFromAssemblyContaining<T>()`
+- `RegisterTypesFromAssemblyContaining(Type type)`
+- `RegisterTypesFromAssembly(Assembly assembly)`
+- `RegisterTypesFromAssemblies(params Assembly[] assemblies)`
 
 Create messages and consumers
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -30,7 +30,7 @@ Provides a fake `IScheduleService` implementation, which is useful for asserting
 Includes two methods to configure your `IServiceCollection` without including the background services for processing messages. 
 
 - `AddFakeAsyncMonolithBaseServices` configures fake services which don't depend on a database
-- `AddRealAsyncMonolithBaseServices` configrues real services without registering the background processors
+- `AddRealAsyncMonolithBaseServices` configures real services without registering the background processors
 
 ### TestConsumerMessageProcessor
 
@@ -55,7 +55,8 @@ public class CancelShipmentTests : ConsumerTestBase
             }
         );
 
-        services.AddRealAsyncMonolithBaseServices<ApplicationDbContext>(typeof(Program).Assembly, AsyncMonolithSettings.Default);
+        services.AddRealAsyncMonolithBaseServices<ApplicationDbContext>(settings =>
+            settings.RegisterTypesFromAssemblyContaining<Program>());
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
Props @Timmoth for the interesting contribution to .NET open source. 🙌

I was checking out your library and noticed that the extension methods on `IServiceCollection` do not return the instance being extended allowing for method chaining. I like to chain my `Add` methods when possible and after looking at the code noticed the issue to allow scanning multiple assemblies. This seems like a useful feature, so I took a stab at an initial implementation.

The approach is to replace the separate arguments on the `Add` methods with a single `Action<AsyncMonolithSettings>` argument that can be used to configure the existing settings while also exposing methods to add the assemblies to be scanned. The concept is borrowed from the way MediatR allows settings and assemblies to be configured. I like this pattern because the settings type can be extended with new capabilities that have defaults without having to introduce additional arguments to the method signatures.

**A summary of the changes:**

- Left the original `Add` methods in place and added an `ObsoleteAttribute` to them
- Introduced new `Add` methods that accept the `Action<AsyncMonolithSettings>` argument
- Add chainable methods to `AsyncMonolithSettings` for registering assemblies using `Assembly` or marker `Type` instances:
  - `RegisterTypesFromAssemblyContaining<T>()`
  - `RegisterTypesFromAssemblyContaining(Type type)`
  - `RegisterTypesFromAssembly(Assembly assembly)`
  - `RegisterTypesFromAssemblies(params Assembly[] assemblies)`
- Move the core service registration logic to a private method that is called by the old and new public `Add` methods
- Use `InternalsVisibleTo` in the core `AsyncMonolith` project to allow methods like `InternalAddAsyncMonolith<T>` to have the `internal` access modifier applied avoiding confusion on what methods should be called
- Return the `ModelBuilder` instance from `ConfigureAsyncMonolith` allowing configuration to be chained
- Added a missing `await` I noticed in the `ValueSubmittedConsumer`
- Updated the `Program` class in the demo to use the new syntax
- Updated the `quickstart.md` and `tests.md` documents to show the new syntax

I don't know if you had a particular direction in mind when you opened the issue, but hopefully these changes are heading in the right direction. Happy to work with you to tweak things to your liking.

Resolves issue #11